### PR TITLE
Add leptos 0.6 support, you must have cargo-leptos 0.2.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 anyhow = "1"
 cfg-if = "1"
 console_error_panic_hook = "0.1"
-http = "0.2"
+http = "1.0"
 leptos = "0.6.6"
 leptos_integration_utils = { version = "0.6.6", optional = true }
 leptos_meta = "0.6.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ leptos = "0.6.5"
 leptos_integration_utils = { version = "0.6.5", optional = true }
 leptos_meta = "0.6.5"
 leptos_router = "0.6.5"
-leptos-spin = { git = "https://github.com/benwis/leptos-spin", branch = "main", optional = true }
+leptos-spin = { version = "0.1.0", optional = true }
 serde = "1.0"
-spin-sdk = { version = "2.1", optional = true }
+spin-sdk = { version = "2.2", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ anyhow = "1"
 cfg-if = "1"
 console_error_panic_hook = "0.1"
 http = "0.2"
-leptos = "0.5.6"
-leptos_integration_utils = { version = "0.5.6", optional = true }
-leptos_meta = "0.5.6"
-leptos_router = "0.5.6"
-leptos-spin = { git = "https://github.com/fermyon/leptos-spin", branch = "main", optional = true }
+leptos = "0.6.5"
+leptos_integration_utils = { version = "0.6.5", optional = true }
+leptos_meta = "0.6.5"
+leptos_router = "0.6.5"
+leptos-spin = { git = "https://github.com/benwis/leptos-spin", branch = "main", optional = true }
 serde = "1.0"
 spin-sdk = { version = "2.1", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "{{project-name}}"
 authors = ["{{authors}}"]
 description = ""
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [lib]
@@ -44,7 +44,7 @@ ssr = [
 
 [package.metadata.leptos]
 # The name used by wasm-bindgen/cargo-leptos for the JS/WASM bundle. Defaults to the crate name
-output-name = "{{crate_name}}"
+bin-target-triple = "wasm32-wasi"
 style-file = "public/main.css"
 bin-features = ["ssr"]
 bin-default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "{{project-name}}"
+name = "{{project-name | snake_case}}"
 authors = ["{{authors}}"]
 description = ""
 version = "0.2.0"
@@ -13,10 +13,10 @@ anyhow = "1"
 cfg-if = "1"
 console_error_panic_hook = "0.1"
 http = "0.2"
-leptos = "0.6.5"
-leptos_integration_utils = { version = "0.6.5", optional = true }
-leptos_meta = "0.6.5"
-leptos_router = "0.6.5"
+leptos = "0.6.6"
+leptos_integration_utils = { version = "0.6.6", optional = true }
+leptos_meta = "0.6.6"
+leptos_router = "0.6.6"
 leptos-spin = { version = "0.1.0", optional = true }
 serde = "1.0"
 spin-sdk = { version = "2.2", optional = true }
@@ -42,10 +42,27 @@ ssr = [
   "dep:leptos_integration_utils",
 ]
 
+# Defines a size-optimized profile for the WASM bundle in release mode
+[profile.wasm-release]
+inherits = "release"
+opt-level = 'z'
+lto = true
+codegen-units = 1
+panic = "abort"
+
+
 [package.metadata.leptos]
-# The name used by wasm-bindgen/cargo-leptos for the JS/WASM bundle. Defaults to the crate name
-bin-target-triple = "wasm32-wasi"
+# [Optional] The source CSS file. If it ends with .sass or .scss then it will be compiled by dart-sass into CSS. The CSS is optimized by Lightning CSS before being written to <site-root>/<site-pkg>/app.css
 style-file = "public/main.css"
+
+# Assets source dir. All files found here will be copied and synchronized to site-root.
+# The assets-dir cannot have a sub directory with the same name/path as site-pkg-dir.
+#
+# Optional. Env: LEPTOS_ASSETS_DIR.
+assets-dir = "public"
+
+# Mandatory fields for Spin apps
+bin-target-triple = "wasm32-wasi"
 bin-features = ["ssr"]
 bin-default-features = false
 lib-features = ["hydrate"]

--- a/spin.toml
+++ b/spin.toml
@@ -2,7 +2,7 @@ spin_manifest_version = 2
 
 [application]
 name = "{{project-name}}"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["{{authors}}"]
 description = ""
 
@@ -16,7 +16,7 @@ allowed_outbound_hosts = []
 key_value_stores = ["default"]
 
 [component.{{project-name | kebab_case}}.build]
-command = "cargo leptos build --release && LEPTOS_OUTPUT_NAME={{crate_name}} cargo build --lib --target wasm32-wasi --release --no-default-features --features ssr"
+command = "cargo leptos build --release"
 watch = ["src/**/*.rs", "Cargo.toml"]
 
 [[trigger.http]]

--- a/src/pages/home.rs
+++ b/src/pages/home.rs
@@ -1,5 +1,9 @@
-use leptos::*;
+use leptos::{
+    component, create_resource, create_server_action, expect_context,
+    view, IntoView, ServerFnError, SignalGet,
+};
 use leptos_router::*;
+use leptos_spin_macro::server;
 
 /// Renders the home page of your application.
 #[component]

--- a/src/pages/home.rs
+++ b/src/pages/home.rs
@@ -1,9 +1,8 @@
 use leptos::{
     component, create_resource, create_server_action, expect_context,
-    view, IntoView, ServerFnError, SignalGet,
+    view, IntoView, ServerFnError, SignalGet,server,
 };
 use leptos_router::*;
-use leptos_spin_macro::server;
 
 /// Renders the home page of your application.
 #[component]
@@ -35,7 +34,7 @@ pub fn Home() -> impl IntoView {
     }
 }
 
-#[server(UpdateCount, "/api")]
+#[server]
 pub async fn update_count() -> Result<(), ServerFnError> {
     println!("Upated count");
 
@@ -43,24 +42,24 @@ pub async fn update_count() -> Result<(), ServerFnError> {
 
     let count: u64 = store
         .get_json("{{crate_name}}_count")
-        .map_err(|e| ServerFnError::ServerError(e.to_string()))?
+        .map_err(|e| ServerFnError::new(e))?
         .unwrap_or_default();
 
     let updated_count = count + 1;
 
     store
         .set_json("{{crate_name}}_count", &updated_count)
-        .map_err(|e| ServerFnError::ServerError(e.to_string()))?;
+        .map_err(|e| ServerFnError::new(e))?;
     Ok(())
 }
 
-#[server(GetCount, "/api")]
+#[server]
 pub async fn get_count() -> Result<u64, ServerFnError> {
     let store = spin_sdk::key_value::Store::open_default()?;
 
     let stored_count: u64 = store
         .get_json("{{crate_name}}_count")
-        .map_err(|e| ServerFnError::ServerError(e.to_string()))?
+        .map_err(|e| ServerFnError::ServerError::new(e))?
         .ok_or_else(|| ServerFnError::ServerError("Failed to get count".to_string()))?;
 
     println!("Got stored {stored_count}");

--- a/src/pages/home.rs
+++ b/src/pages/home.rs
@@ -1,7 +1,4 @@
-use leptos::{
-    component, create_resource, create_server_action, expect_context,
-    view, IntoView, ServerFnError, SignalGet,server,
-};
+use leptos::{server_fn::error::NoCustomError, *};
 use leptos_router::*;
 
 /// Renders the home page of your application.
@@ -59,8 +56,10 @@ pub async fn get_count() -> Result<u64, ServerFnError> {
 
     let stored_count: u64 = store
         .get_json("{{crate_name}}_count")
-        .map_err(|e| ServerFnError::ServerError::new(e))?
-        .ok_or_else(|| ServerFnError::ServerError("Failed to get count".to_string()))?;
+        .map_err(|e| ServerFnError::new(e))?
+        .ok_or_else(|| {
+            ServerFnError::<NoCustomError>::ServerError("Failed to get count".to_string())
+        })?;
 
     println!("Got stored {stored_count}");
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,5 +1,5 @@
 use leptos::ServerFn;
-use leptos_spin::{render_best_match_to_stream, RouteTable};
+use leptos_spin::{render_best_match_to_stream, RouteTable, server_fn::register_explicit};
 use spin_sdk::http::{IncomingRequest, ResponseOutparam};
 use spin_sdk::http_component;
 
@@ -9,8 +9,8 @@ async fn handle_{{crate_name}}(req: IncomingRequest, resp_out: ResponseOutparam)
     conf.leptos_options.output_name = "{{crate_name}}".to_owned();
 
     // Register server functions
-    crate::pages::home::GetCount::register_explicit().unwrap();
-    crate::pages::home::UpdateCount::register_explicit().unwrap();
+    register_explicit::<crates::pages::home::GetCount>();
+    register_explicit::<crate::pages::home::UpdateCount>();
 
     let app_router = crate::routes::AppRouter;
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,4 +1,3 @@
-use leptos::ServerFn;
 use leptos_spin::{render_best_match_to_stream, RouteTable, server_fn::register_explicit};
 use spin_sdk::http::{IncomingRequest, ResponseOutparam};
 use spin_sdk::http_component;
@@ -9,7 +8,7 @@ async fn handle_{{crate_name}}(req: IncomingRequest, resp_out: ResponseOutparam)
     conf.leptos_options.output_name = "{{crate_name}}".to_owned();
 
     // Register server functions
-    register_explicit::<crates::pages::home::GetCount>();
+    register_explicit::<crate::pages::home::GetCount>();
     register_explicit::<crate::pages::home::UpdateCount>();
 
     let app_router = crate::routes::AppRouter;


### PR DESCRIPTION
@diversable I've created a PR for start-spin with leptos 0.6. We're waiting for them to release a new version with the changes, but it'd be good for you to try testing this with a git dependency for leptos-spin 
https://github.com/benwis/leptos-spin

@itowlson Here's the changes I made to the template to support leptos 0.6